### PR TITLE
Make number of type errors reported configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,38 @@ Both `vertices` and `edges` attributes are optional.
 
 ##### Attribute Specification
 
-You can declare the vertex and edge attributes upfront with their types for efficient columnar storage:
+You can declare the vertex and edge attributes upfront with their types for efficient columnar storage.
 
-```json
-{ "name": "string", "age": "number" }
-```
+**Supported Data Types:**
+
+- **`DataType::Bool`** - Boolean values
+  - Accepts: `true`/`false`, strings like "true"/"false"/"yes"/"no"/"1"/"0", numbers (0=false, non-zero=true)
+  
+- **`DataType::String`** - Text strings
+  - Accepts: any value (null becomes empty string, objects/arrays become JSON strings)
+  
+- **`DataType::U64`** - Unsigned 64-bit integers (non-negative)
+  - Accepts: non-negative integers, positive floats (rounded), numeric strings
+  - Rejects: negative values
+  
+- **`DataType::I64`** - Signed 64-bit integers
+  - Accepts: any integer, floats (rounded), numeric strings
+  
+- **`DataType::F64`** - 64-bit floating point numbers
+  - Accepts: any numeric value, numeric strings
+  - Rejects: infinity and NaN values
+  
+- **`DataType::JSON`** - Any JSON value
+  - Accepts: anything without type conversion
+
+**Type Conversion Errors:**
+
+When a value cannot be converted to the specified type, a default value is used and the error is recorded:
+- `Bool` → `false`
+- `String` → `""` (empty string)
+- `U64` / `I64` → `0`
+- `F64` → `0.0`
+- `JSON` → `null`
 
 The `_id` attribute for vertices and `_from`/`_to` attributes for edges are automatically included and don't need to be specified.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can declare the vertex and edge attributes upfront with their types for effi
 - **`DataType::I64`** - Signed 64-bit integers
   - Accepts: any integer, floats (rounded), numeric strings
   
-- **`DataType::F64`** - 64-bit floating point numbers
+- **`DataType::F64`** - 64-bit floating-point numbers
   - Accepts: any numeric value, numeric strings
   - Rejects: infinity and NaN values
   

--- a/README.md
+++ b/README.md
@@ -229,7 +229,19 @@ async fn create_aql_graph_loader() -> Result<AqlGraphLoader, GraphLoaderError> {
         vec![edge_query],                    // Then load edges
     ];
     
-    AqlGraphLoader::new(db_config, batch_size, vertex_attributes, edge_attributes, queries).await
+    // Configure type error reporting limit
+    // None = report all type errors (recommended default)
+    // Some(n) = report at most n type errors per GraphBatch
+    let max_type_errors = None;
+    
+    AqlGraphLoader::new(
+        db_config,
+        batch_size,
+        vertex_attributes,
+        edge_attributes,
+        queries,
+        max_type_errors
+    )
 }
 ```
 
@@ -265,7 +277,7 @@ async fn create_traversal_loader() -> Result<AqlGraphLoader, GraphLoaderError> {
     
     let queries = vec![vec![traversal_query]];
     
-    AqlGraphLoader::new(db_config, batch_size, vertex_attributes, edge_attributes, queries).await
+    AqlGraphLoader::new(db_config, batch_size, vertex_attributes, edge_attributes, queries, None)
 }
 ```
 
@@ -318,7 +330,33 @@ The callback receives a mutable reference to a `GraphBatch` containing both vert
 - **edge_to_ids**: Vector of target vertex IDs as byte vectors
 - **edge_attribute_values**: Vector of attribute vectors, parallel to edge IDs
 - **type_error_count**: Total number of type conversion errors encountered
-- **type_error_messages**: First few type error messages (up to 10)
+- **type_error_messages**: Type error messages (limited based on configuration)
+
+#### Type Error Reporting Configuration
+
+The `AqlGraphLoader` allows you to configure how many type error messages are collected per `GraphBatch`:
+
+- **`None` (recommended default)**: All type conversion errors are reported. This is useful for debugging and ensures you see every issue.
+- **`Some(n)`**: At most `n` type error messages are collected per `GraphBatch`. The total count is always tracked in `type_error_count`, but only the first `n` messages are stored in `type_error_messages`. This can help reduce memory usage when dealing with data that has many type errors.
+- **`Some(0)`**: No error messages are collected (but `type_error_count` is still incremented). Use this if you only need to know the count of errors, not the details.
+
+Examples:
+```rust
+// Report all type errors (recommended)
+let loader = AqlGraphLoader::new(
+    db_config, batch_size, vertex_attrs, edge_attrs, queries, None
+)?;
+
+// Report at most 10 type errors per batch
+let loader = AqlGraphLoader::new(
+    db_config, batch_size, vertex_attrs, edge_attrs, queries, Some(10)
+)?;
+
+// Track error count only, no messages
+let loader = AqlGraphLoader::new(
+    db_config, batch_size, vertex_attrs, edge_attrs, queries, Some(0)
+)?;
+```
 
 The callback signature is:
 

--- a/docs/GetGraphsOutOfArangoDBviaAQL.md
+++ b/docs/GetGraphsOutOfArangoDBviaAQL.md
@@ -17,14 +17,14 @@ we need another additional approach, which is:
  
 Therefore, we take as guiding principle two common use cases:
 
- 1. The subgraph is defined by naming the vertex collection(s) and
-    specifying a `FILTER` condition to say which vertices are taken, and by
-    naming the edge collection(s) and specifying a `FILTER` condition to say
-    which edges are taken. The `FILTER` conditions might be so that indexes
-    can help with the selection.
+1. The subgraph is defined by naming the vertex collection(s) and
+   specifying a `FILTER` condition to say which vertices are taken, and by
+   naming the edge collection(s) and specifying a `FILTER` condition to say
+   which edges are taken. The `FILTER` conditions might be so that indexes
+   can help with the selection.
 
- 2. The subgraph is defined by specifying one (or more) graph traversals 
-    which "finds" the subgraph to be exported.
+2. The subgraph is defined by specifying one (or more) graph traversals 
+   which "finds" the subgraph to be exported.
 
 Other use cases are of course possible and should also be supported, but
 we use these two for inspiration about the way we want to specify the
@@ -128,7 +128,7 @@ with their data types. The following data types are supported:
 - **`String`** - Text strings (accepts any value and converts it to string)
 - **`U64`** - Unsigned 64-bit integers (non-negative integers, positive floats are rounded)
 - **`I64`** - Signed 64-bit integers (any integer, floats are rounded)
-- **`F64`** - 64-bit floating point numbers (any numeric value, must be finite)
+- **`F64`** - 64-bit floating-point numbers (any numeric value, must be finite)
 - **`JSON`** - Any JSON value (accepts anything as-is without conversion)
 
 Example in Rust:

--- a/docs/GetGraphsOutOfArangoDBviaAQL.md
+++ b/docs/GetGraphsOutOfArangoDBviaAQL.md
@@ -1,0 +1,188 @@
+# Getting a graph out of ArangoDB via AQL
+
+This proposal is about getting a subgraph of a graph in ArangoDB out using
+AQL. We want to use this in particular in the Graph Analytics Engine (GAE) and
+in Python code for graph analytics.
+
+
+## Motivation
+
+We already have a very fast and scalable method to get a full ArangoDB
+graph out (with some limited amount of filtering and projections), so now
+we need another additional approach, which is:
+
+ - as flexible as possible, and
+ - well suited for relatively small subgraphs, and
+ - which allows to use indexes or traversals to find the right subgraph
+ 
+Therefore, we take as guiding principle two common use cases:
+
+ 1. The subgraph is defined by naming the vertex collection(s) and
+    specifying a `FILTER` condition to say which vertices are taken, and by
+    naming the edge collection(s) and specifying a `FILTER` condition to say
+    which edges are taken. The `FILTER` conditions might be so that indexes
+    can help with the selection.
+
+ 2. The subgraph is defined by specifying one (or more) graph traversals 
+    which "finds" the subgraph to be exported.
+
+Other use cases are of course possible and should also be supported, but
+we use these two for inspiration about the way we want to specify the
+export.
+
+Note that AQL does not make it particularly easy to produce results which
+come from **different** collections. For example, there is no easy way to
+return the union of two (filtered) collections:
+
+```aql
+LET l1 = (FOR x IN coll1
+            FILTER x.type == "xyz"
+            RETURN x)
+LET l2 = (FOR y IN coll2
+            FILTER y.type == "abc"
+            RETURN y)
+FOR z IN CONCATENATION(l1, l2)
+  RETURN z
+```
+
+is possible, but not very efficient, and prone to OOM situations for larger
+data. It is currently not very well optimized and streaming thus does not
+work well.
+
+This observation basically suggests, that it should be possible to give
+**multiple** queries to get all vertices and all edges.
+
+For the GAE it is currently particularly welcome, if all **vertices** are
+exported before the **edges** arrive. If this is the case, then the edge-import
+can directly verify the incoming edges to see if their end-vertices exist
+and can thus avoid dangling edges and can encode the edge in a very 
+memory-efficient way.
+
+This observation suggests, that it should be possible to produce the
+vertices first and then the edges.
+
+However for the graph traversal cases, the vertices and edges are produced
+at the same time, so this suggests that the GAE must also be able to store
+the incoming edges till the end, and only then validate them. In any case,
+the user needs control over the order of execution.
+
+At the same time, parallelism should also be possible for performance
+benefits. For example, it is trivially parallelizable to export vertices
+from different vertex collections concurrently.
+
+Although it is easy to distinguish a vertex from an edge by checking if there
+are attributes `_from` and `_to`, it is also not possible to just assume that
+the set of AQL results are simply a mixture of vertices and edges. Namyle, in 
+a query like:
+
+```aql
+FOR v, e IN 1..10 OUTBOUND @startid GRAPH "blabla"
+  RETURN {v, e}
+```
+
+it is not easily possible to return the produced vertices and edges
+**as different AQL results in the same stream**.
+
+This suggests, that we want to always explicitly mark which results are
+vertices and which are edges, to allow for returning both vertices and
+edges **in the same AQL item in the output stream**.
+
+All this considerations have lead to the proposal below.
+
+
+## Proposal for a graph specification
+
+A "graph loading specification" is a list of lists of AQL queries, each
+of which is a pair of a query string and a map of bind parameters. The
+meaning is as follows: The outer list is worked on **sequentially**. For
+each inner list, the queries can be executed in parallel. Each query has
+to return items of the form:
+
+```json
+{"vertices":[...], "edges":[...]}
+```
+
+and both `vertices` and `edges` attributes are optional. The entries in
+the value of the `vertices` attribute are vertices in the form of JSON
+objects, which must at least have an `_id` attribute. The entries in the
+value of the `edges` attribute are edges and must each have at least
+attributes `_from` and `_to`. It is allowed that an edge value is `null`
+and is then silently ignored (this is important for the start node of a
+graph traversal, where instead of an edge we only have `null`).
+
+It is allowed to produce an item which contains an edge whose end-vertices
+only occur later in the same query or in a later (or parallel) query. In that
+case the GAE will postpone the insertion of the edge and buffer such
+edges. It is advisable to first produce the vertices and then the edges,
+since then the GAE has to buffer less data and can immediately convert the 
+edges into their memory-efficient memory format.
+
+For efficiency reasons, one should declare the attributes which are returned
+for vertices and edges upfront and potentially even prescribe their types,
+so that a nice columnar storage format can be used in the GAE.
+
+In the Rust implementation, attributes are specified using the `DataItem` struct
+with their data types. The following data types are supported:
+
+- **`Bool`** - Boolean values (accepts booleans, strings like "true"/"false", numbers where 0=false)
+- **`String`** - Text strings (accepts any value and converts it to string)
+- **`U64`** - Unsigned 64-bit integers (non-negative integers, positive floats are rounded)
+- **`I64`** - Signed 64-bit integers (any integer, floats are rounded)
+- **`F64`** - 64-bit floating point numbers (any numeric value, must be finite)
+- **`JSON`** - Any JSON value (accepts anything as-is without conversion)
+
+Example in Rust:
+
+```rust
+let vertex_attributes = vec![
+    DataItem::new("name".to_string(), DataType::String),
+    DataItem::new("age".to_string(), DataType::U64),
+    DataItem::new("score".to_string(), DataType::F64),
+    DataItem::new("active".to_string(), DataType::Bool),
+];
+```
+
+The attribute `_id` for vertices and the attributes `_from` and `_to` for edges
+do not have to be specified as they are automatically included.
+
+
+## How this can be used for the typical use cases above
+
+For the above use case 1 (multiple filtered vertex and edge collections),
+this setup can be used as follows:
+
+```json
+[ [{"query":"FOR x IN vertices1 FILTER x. ... RETURN {vertices:[x]}", "bindVars":{}},
+   {"query":"FOR x IN vertices2 FILTER x. ... RETURN {vertices:[x]}", "bindVars":{}}
+  ],
+  [{"query":"FOR y IN edges1 FILTER y. ... RETURN {edges:[y]}", "bindVars":{}},
+   {"query":"FOR y IN edges2 FILTER y. ... RETURN {edges:[y]}", "bindVars":{}}
+  ] ]
+```
+
+The parallelisation rules would ensure, that first all vertices from all
+vertex collections are loaded concurrently, and then all edges from all
+edge collections are loaded concurrently. This means the GAE does not have
+to buffer edges.
+
+For the above use case 2 (graph traversals), this setup can be used as follows:
+
+```json
+[ [{"query":"FOR s IN @startids1 FOR x, y IN 0..10 OUTBOUND s GRAPH 'blabla' PRUNE ... FILTER ... RETURN {vertices:[x], edges:[y]}",
+    "bindVars": {}},
+   {"query":"FOR s IN @startids2 FOR x, y IN 0..10 OUTBOUND s GRAPH 'blabla' PRUNE ... FILTER ... RETURN {vertices:[x], edges:[y]}",
+    "bindVars": {}} ]
+]
+```
+
+Note that the depth 0 is possible, in which case `y` is `null` and `x` is the
+starting vertex. Furthermore, note that the graph traversals would be run
+in parallel. To avoid this, one could use this:
+
+```json
+[ [{"query":"FOR s IN @startids1 FOR x, y IN 0..10 OUTBOUND s GRAPH 'blabla' PRUNE ... FILTER ... RETURN {vertices:[x], edges:[y]}"],
+    "bindVars": {} }],
+  [{"query":"FOR s IN @startids2 FOR x, y IN 0..10 OUTBOUND s GRAPH 'blabla' PRUNE ... FILTER ... RETURN {vertices:[x], edges:[y]}"],
+    "bindVars": {} }]
+]
+```

--- a/docs/GetGraphsOutOfArangoDBviaAQL.md
+++ b/docs/GetGraphsOutOfArangoDBviaAQL.md
@@ -72,7 +72,7 @@ from different vertex collections concurrently.
 
 Although it is easy to distinguish a vertex from an edge by checking if there
 are attributes `_from` and `_to`, it is also not possible to just assume that
-the set of AQL results are simply a mixture of vertices and edges. Namyle, in 
+the set of AQL results are simply a mixture of vertices and edges. Namely, in 
 a query like:
 
 ```aql

--- a/src/aql_graph_loader.rs
+++ b/src/aql_graph_loader.rs
@@ -44,8 +44,10 @@ pub struct GraphBatch {
     pub edge_attribute_values: Vec<Vec<Value>>,
     /// Total number of type conversion errors encountered
     pub type_error_count: usize,
-    /// First few type error messages (up to 10)
+    /// Type error messages (limited based on configuration)
     pub type_error_messages: Vec<String>,
+    /// Maximum number of type error messages to collect (None = no limit)
+    max_type_errors: Option<u64>,
 }
 
 impl DataItem {
@@ -55,7 +57,7 @@ impl DataItem {
 }
 
 impl GraphBatch {
-    fn new() -> Self {
+    fn new(max_type_errors: Option<u64>) -> Self {
         GraphBatch {
             vertex_ids: Vec::new(),
             vertex_attribute_values: Vec::new(),
@@ -64,12 +66,19 @@ impl GraphBatch {
             edge_attribute_values: Vec::new(),
             type_error_count: 0,
             type_error_messages: Vec::new(),
+            max_type_errors,
         }
     }
 
     fn add_type_error(&mut self, message: String) {
         self.type_error_count += 1;
-        if self.type_error_messages.len() < 10 {
+        // Add message only if we haven't reached the limit (or if there's no limit)
+        if let Some(max) = self.max_type_errors {
+            if (self.type_error_messages.len() as u64) < max {
+                self.type_error_messages.push(message);
+            }
+        } else {
+            // No limit, add all messages
             self.type_error_messages.push(message);
         }
     }
@@ -288,6 +297,8 @@ pub struct AqlGraphLoader {
     vertex_attributes: Vec<DataItem>,
     edge_attributes: Vec<DataItem>,
     queries: Vec<Vec<AqlQuery>>,
+    /// Maximum number of type error messages to collect per GraphBatch (None = no limit)
+    max_type_errors: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -342,12 +353,24 @@ struct GraphData {
 
 impl AqlGraphLoader {
     /// Create a new AQL graph loader
+    ///
+    /// # Arguments
+    ///
+    /// * `db_config` - Database configuration
+    /// * `batch_size` - Size of batches to fetch from the database
+    /// * `vertex_attributes` - List of vertex attributes to load with their types
+    /// * `edge_attributes` - List of edge attributes to load with their types
+    /// * `queries` - Nested list of AQL queries (outer list = sequential, inner list = parallel)
+    /// * `max_type_errors` - Maximum number of type error messages to collect per GraphBatch
+    ///   - `None` (recommended default): All type errors are reported
+    ///   - `Some(n)`: At most n type error messages are collected per GraphBatch (can be 0)
     pub fn new(
         db_config: DatabaseConfiguration,
         batch_size: u64,
         vertex_attributes: Vec<DataItem>,
         edge_attributes: Vec<DataItem>,
         queries: Vec<Vec<AqlQuery>>,
+        max_type_errors: Option<u64>,
     ) -> Result<Self, GraphLoaderError> {
         // Validate that we have at least one query
         if queries.is_empty() || queries.iter().all(|q| q.is_empty()) {
@@ -362,6 +385,7 @@ impl AqlGraphLoader {
             vertex_attributes,
             edge_attributes,
             queries,
+            max_type_errors,
         })
     }
 
@@ -404,6 +428,7 @@ impl AqlGraphLoader {
         let callback_clone = callback.clone();
         let vertex_attributes = self.vertex_attributes.clone();
         let edge_attributes = self.edge_attributes.clone();
+        let max_type_errors = self.max_type_errors;
 
         let consumer = std::thread::spawn(move || -> Result<(), GraphLoaderError> {
             while let Some(resp) = receiver.blocking_recv() {
@@ -441,7 +466,7 @@ impl AqlGraphLoader {
                 }
 
                 // Create a single batch for this database response
-                let mut batch = GraphBatch::new();
+                let mut batch = GraphBatch::new(max_type_errors);
 
                 // Process each item in the result array and accumulate into the batch
                 for item in result_array.unwrap() {
@@ -1009,7 +1034,8 @@ mod tests {
 
     #[test]
     fn test_graph_batch_type_error_tracking() {
-        let mut batch = GraphBatch::new();
+        // Test with a limit of 10
+        let mut batch = GraphBatch::new(Some(10));
 
         assert_eq!(batch.type_error_count, 0);
         assert_eq!(batch.type_error_messages.len(), 0);
@@ -1027,6 +1053,42 @@ mod tests {
         // Count should be 12, but messages capped at 10
         assert_eq!(batch.type_error_count, 12);
         assert_eq!(batch.type_error_messages.len(), 10);
+    }
+
+    #[test]
+    fn test_graph_batch_type_error_no_limit() {
+        // Test with no limit
+        let mut batch = GraphBatch::new(None);
+
+        assert_eq!(batch.type_error_count, 0);
+        assert_eq!(batch.type_error_messages.len(), 0);
+
+        // Add errors
+        for i in 1..=15 {
+            batch.add_type_error(format!("Error {}", i));
+        }
+
+        // All 15 errors should be tracked
+        assert_eq!(batch.type_error_count, 15);
+        assert_eq!(batch.type_error_messages.len(), 15);
+    }
+
+    #[test]
+    fn test_graph_batch_type_error_zero_limit() {
+        // Test with zero limit (no messages collected, but count still tracked)
+        let mut batch = GraphBatch::new(Some(0));
+
+        assert_eq!(batch.type_error_count, 0);
+        assert_eq!(batch.type_error_messages.len(), 0);
+
+        // Add errors
+        for i in 1..=5 {
+            batch.add_type_error(format!("Error {}", i));
+        }
+
+        // Count should be 5, but no messages collected
+        assert_eq!(batch.type_error_count, 5);
+        assert_eq!(batch.type_error_messages.len(), 0);
     }
 
     #[test]

--- a/src/load.rs
+++ b/src/load.rs
@@ -36,6 +36,7 @@ pub fn load_aql_graph(
     vertex_attributes: Vec<DataItem>,
     edge_attributes: Vec<DataItem>,
     queries: Vec<Vec<AqlQuery>>,
+    max_type_errors: Option<u64>,
 ) -> Result<AqlGraphLoader, GraphLoaderError> {
     AqlGraphLoader::new(
         db_config,
@@ -43,5 +44,6 @@ pub fn load_aql_graph(
         vertex_attributes,
         edge_attributes,
         queries,
+        max_type_errors,
     )
 }

--- a/tests/graph_loader.rs
+++ b/tests/graph_loader.rs
@@ -978,6 +978,7 @@ async fn test_aql_graph_loader_full_topology() {
         vec![], // No vertex attributes
         vec![], // No edge attributes
         vec![vec![vertex_query], vec![edge_query]],
+        None, // No limit on type errors
     )
     .unwrap();
 
@@ -1128,6 +1129,7 @@ async fn test_aql_graph_loader_filtered_with_depth() {
         vec![DataItem::new("depth".to_string(), DataType::U64)],
         vec![DataItem::new("depth".to_string(), DataType::U64)],
         vec![vec![vertex_query], vec![edge_query]],
+        None, // No limit on type errors
     )
     .unwrap();
 
@@ -1286,6 +1288,7 @@ async fn test_aql_graph_loader_left_edges_only() {
         vec![DataItem::new("depth".to_string(), DataType::U64)],
         vec![DataItem::new("depth".to_string(), DataType::U64)],
         vec![vec![vertex_query, edge_query]],
+        None, // No limit on type errors
     )
     .unwrap();
 
@@ -1422,6 +1425,7 @@ async fn test_aql_graph_loader_traversal_depth_6() {
         vec![],                                                  // No vertex attributes
         vec![DataItem::new("depth".to_string(), DataType::U64)], // Edge depth only
         vec![vec![traversal_query]],                             // Single query
+        None,                                                    // No limit on type errors
     )
     .unwrap();
 


### PR DESCRIPTION
This adds an option for the `AqlGraphLoader` to specify how many
type errors there will be reported per `GraphBatch` in the callback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable per-batch type-error reporting: unlimited, capped (n messages), or suppressed (messages omitted but counts tracked).

* **Documentation**
  * Expanded attribute typing and type-conversion rules, plus examples for None, Some(n) and Some(0) reporting modes.
  * New AQL-based graph export guide with usage patterns and typing examples.

* **Breaking Changes**
  * Public APIs extended to accept an optional parameter to control per-batch type-error reporting.

* **Tests**
  * Added tests covering unlimited, capped, and zero-message scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable per-batch type error reporting for AQL-based graph loading and expands documentation.
> 
> - `AqlGraphLoader::new` and `load_aql_graph` extended with `max_type_errors: Option<u64>`; `GraphBatch` now enforces the message cap while always tracking `type_error_count`
> - Updated processing path to pass the limit into batches; added tests for capped, unlimited, and zero-limit behaviors
> - README: clarified attribute typing, conversion rules, and error reporting examples; code samples updated to include the new parameter
> - New doc `docs/GetGraphsOutOfArangoDBviaAQL.md` describing the AQL-based graph export spec and usage patterns
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed39e4b7e49a64dfbdfe270c10d8a3437cd8e406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->